### PR TITLE
Add OIDC-based publish workflow with release label gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - skip-release
     cooldown:
       default-days: 7
   - package-ecosystem: npm
@@ -12,6 +14,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    labels:
+      - skip-release
     ignore:
       - dependency-name: "rollup"
       - dependency-name: "@rollup/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          always-auth: false
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          always-auth: false
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+---
+name: publish
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Determine version bump
+        id: version
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version
+        id: bump
+        env:
+          VERSION_BUMP: ${{ steps.version.outputs.bump }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          NEW_VERSION=$(pnpm version "$VERSION_BUMP" -m "chore: release v%s")
+          echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "$REMOTE" "HEAD:${BASE_REF}"
+          git push "$REMOTE" --tags
+
+      - name: Publish to npm
+        run: pnpm publish --access public --provenance --no-git-checks
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.bump.outputs.tag }}
+        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,13 +50,15 @@ jobs:
 
       - name: Determine version bump
         id: version
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
-            echo "bump=major" >> $GITHUB_OUTPUT
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
+          if echo "$LABELS" | grep -q '"major"'; then
+            echo "bump=major" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -q '"minor"'; then
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
           else
-            echo "bump=patch" >> $GITHUB_OUTPUT
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Bump version
@@ -67,7 +69,7 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           NEW_VERSION=$(pnpm version "$VERSION_BUMP" -m "chore: release v%s")
-          echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push "$REMOTE" "HEAD:${BASE_REF}"
           git push "$REMOTE" --tags

--- a/.github/workflows/release-label.yml
+++ b/.github/workflows/release-label.yml
@@ -1,0 +1,33 @@
+---
+name: release-label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Ensure supported release label is set
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "PR labels: $LABELS"
+          if echo "$LABELS" | grep -E -q '"(patch|minor|major)"'; then
+            echo "Supported release label found."
+            exit 0
+          fi
+          echo "::error::PR must have one of the supported release labels: patch, minor, or major."
+          exit 1

--- a/.github/workflows/release-label.yml
+++ b/.github/workflows/release-label.yml
@@ -25,9 +25,9 @@ jobs:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           echo "PR labels: $LABELS"
-          if echo "$LABELS" | grep -E -q '"(patch|minor|major)"'; then
+          if echo "$LABELS" | grep -E -q '"(patch|minor|major|skip-release)"'; then
             echo "Supported release label found."
             exit 0
           fi
-          echo "::error::PR must have one of the supported release labels: patch, minor, or major."
+          echo "::error::PR must have one of the supported release labels: patch, minor, major, or skip-release."
           exit 1

--- a/.github/workflows/release-label.yml
+++ b/.github/workflows/release-label.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Ensure supported release label is set
         env:
-          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           echo "PR labels: $LABELS"
           if echo "$LABELS" | grep -E -q '"(patch|minor|major|skip-release)"'; then

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml`: triggers on merged PRs to `main`, gated by `patch` / `minor` / `major` labels. Uses OIDC (`id-token: write`) to publish to npm with provenance, bumps the version with `pnpm version`, pushes the tag, and creates a GitHub release. Modeled after [kibertoad/toad-cache's publish workflow](https://github.com/kibertoad/toad-cache/blob/main/.github/workflows/publish.yml).
- Adds `.github/workflows/release-label.yml`: a required PR check that fails until one of the supported release labels (`patch`, `minor`, `major`) is set, so merging without a label can't silently skip a release.

## Notes
- Requires npm package settings to trust this GitHub repo/workflow for OIDC trusted publishing (no `NPM_TOKEN` secret needed).
- Action versions are pinned by commit SHA to keep zizmor happy.

## Test plan
- [ ] Confirm npm trusted publisher is configured for `butter-spread` pointing at `kibertoad/butter-spread` and `publish.yml`
- [ ] Create a throwaway PR without any release label and confirm the `release-label` check fails
- [ ] Add a `patch` label and confirm the check turns green
- [ ] On the next real release, merge a labeled PR and verify version bump, npm publish with provenance, tag push, and GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)