### PR TITLE
Fix publish workflow: reliably tag and release after npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,17 +65,23 @@ jobs:
         id: bump
         env:
           VERSION_BUMP: ${{ steps.version.outputs.bump }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          NEW_VERSION=$(pnpm version "$VERSION_BUMP" -m "chore: release v%s")
+          pnpm version "$VERSION_BUMP" -m "chore: release v%s"
+          NEW_VERSION="v$(node -p "require('./package.json').version")"
           echo "tag=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push "$REMOTE" "HEAD:${BASE_REF}"
-          git push "$REMOTE" --tags
 
       - name: Publish to npm
         run: pnpm publish --access public --provenance --no-git-checks
+
+      - name: Push commit and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          RELEASE_TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "$REMOTE" "HEAD:${BASE_REF}"
+          git push "$REMOTE" "$RELEASE_TAG"
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
## Root cause of the v5.0.1 failure

`pnpm version patch` doesn't print `v5.0.1` to stdout like `npm version` does — it prints `butter-spread: 5.0.0 → 5.0.1`. That string was captured into `NEW_VERSION` and the resulting `tag=butter-spread: 5.0.0 → 5.0.1` line was invalid `$GITHUB_OUTPUT` syntax, so the **Bump version** step errored out — but only *after* it had already pushed the version-bump commit and the `v5.0.1` tag to `main`. Result: repo says 5.0.1, npm still says 5.0.0, no GitHub release.

## What this PR changes

- **Read the new version from `package.json`** (`node -p "require('./package.json').version"`) instead of from `pnpm version` stdout.
- **Run `pnpm publish` before pushing the commit and tag.** Previously: bump+push → publish → release. Now: bump → publish → push commit+tag → create release. If npm publish fails, no commit, no tag, no release end up on the repo — the runner just discards them.
- **Push only the specific release tag** instead of `--tags`.

## Heads-up: state of `main`

`main` currently sits at the `chore: release v5.0.1` commit with a `v5.0.1` tag, but npm only has `5.0.0` and there's no `v5.0.1` GitHub release. Options:

- Manually `npm publish` from `main` (and `gh release create v5.0.1 --generate-notes`) to retroactively complete the 5.0.1 release; or
- Leave 5.0.1 skipped on npm — the next labeled-merge will bump to 5.0.2 and publish normally with the fixed workflow.

## Test plan
- [ ] Decide whether to retroactively publish 5.0.1 to npm or skip it
- [ ] Next merged release PR (with `patch`/`minor`/`major` label) publishes to npm, then pushes commit+tag, then creates the GitHub release — all three artifacts present
- [ ] If a future `pnpm publish` ever fails, no orphan tag/commit on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)