### PR TITLE
Address review feedback: bugs, perf, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Note that you should also consider using worker threads; [piscina](https://githu
 
 If you have to run your app in an environment that only has a single core, your processing typically completes fast (but can sometimes spike), or you are searching for a simpler solution, look no further than this library!
 
+## Requirements
+
+Node.js `>= 22.13` (declared via `engines.node` with `engineStrict: true` — older versions will be rejected at install time).
+
 ## Node.js task queue consideration
 
-Each following chunk of work is added to the end of the event loop task queue after previous one is finished.
+Each following chunk of work is added to the end of the event loop task queue after the previous one is finished. The yielding primitive is [`setImmediate`](https://nodejs.org/api/timers.html#setimmediatecallback-args), which runs after pending I/O — not `process.nextTick` or `queueMicrotask`, which do not yield to I/O.
 
 This potentially increases latency of processing a single batch operation while improving throughput - all new work that was received after first chunk started processing will be completed before second chunk will be processed.
 
@@ -103,6 +107,8 @@ const results = await executeTwoPhaseChunksSequentially(chunks, {
 })
 ```
 
+Setting `executeSynchronouslyThresholdInMsecs: 0` flushes after every sync transform — useful when downstream ordering or backpressure dictates one-at-a-time processing. Output order across batches is preserved (each `asyncPostProcess` call is awaited before the next sync transform begins).
+
 ## Stream utilities
 
 ### batchFromStream
@@ -173,3 +179,9 @@ import { getSlicePreserveWords } from 'butter-spread'
 getSlicePreserveWords('hello world foo bar', 11) // 'hello world'
 getSlicePreserveWords('hello world foo bar', 11, 6) // 'world foo'
 ```
+
+The optional `startPos` argument is expected to coincide with a word boundary (for example, the offset returned as the end of a previous slice). If it lands mid-word, the returned slice will start mid-word too.
+
+## Logger
+
+`Logger` is a minimal `{ warn: LogFn }` shape, intentionally compatible with [pino](https://github.com/pinojs/pino) and similar structured loggers. The default `defaultLogger` exposes only `warn` (backed by `console.warn`) — the rest of `console` is not part of the surface area.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@kibertoad/biome-config": "^2.0.0",
-    "@types/node": "^20.16.10",
+    "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^3.2.4",
     "del-cli": "^7.0.0",
     "fastify": "^5.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@biomejs/biome@2.4.15)
       '@types/node':
-        specifier: ^20.16.10
-        version: 20.19.41
+        specifier: ^22.10.0
+        version: 22.19.19
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@20.19.41))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.19))
       del-cli:
         specifier: ^7.0.0
         version: 7.0.0
@@ -37,7 +37,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.41)
+        version: 3.2.4(@types/node@22.19.19)
 
 packages:
 
@@ -712,8 +712,8 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@20.19.41':
-    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -2130,11 +2130,11 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@20.19.41':
+  '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.41))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.19))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2149,7 +2149,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.41)
+      vitest: 3.2.4(@types/node@22.19.19)
     transitivePeerDependencies:
       - supports-color
 
@@ -2161,13 +2161,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@20.19.41))':
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.19))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@20.19.41)
+      vite: 7.3.3(@types/node@22.19.19)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2847,13 +2847,13 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
-  vite-node@3.2.4(@types/node@20.19.41):
+  vite-node@3.2.4(@types/node@22.19.19):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@20.19.41)
+      vite: 7.3.3(@types/node@22.19.19)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2868,7 +2868,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.3(@types/node@20.19.41):
+  vite@7.3.3(@types/node@22.19.19):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2877,14 +2877,14 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
       fsevents: 2.3.3
 
-  vitest@3.2.4(@types/node@20.19.41):
+  vitest@3.2.4(@types/node@22.19.19):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@20.19.41))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@22.19.19))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2902,11 +2902,11 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@20.19.41)
-      vite-node: 3.2.4(@types/node@20.19.41)
+      vite: 7.3.3(@types/node@22.19.19)
+      vite-node: 3.2.4(@types/node@22.19.19)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.41
+      '@types/node': 22.19.19
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/arrayUtils.ts
+++ b/src/arrayUtils.ts
@@ -1,11 +1,16 @@
+/**
+ * Splits `array` into consecutive sub-arrays of length `chunkSize` (the last chunk
+ * may be smaller). Returns an empty array if `array` is empty or if `chunkSize` is
+ * not a positive finite number.
+ */
 export function chunk<T>(array: T[], chunkSize: number): T[][] {
   const length = array.length
-  if (!length || chunkSize < 1) {
+  if (!length || !Number.isFinite(chunkSize) || chunkSize < 1) {
     return []
   }
   let index = 0
   let resIndex = 0
-  const result = new Array(Math.ceil(length / chunkSize))
+  const result = new Array<T[]>(Math.ceil(length / chunkSize))
 
   while (index < length) {
     result[resIndex++] = array.slice(index, (index += chunkSize))

--- a/src/butterSpread.ts
+++ b/src/butterSpread.ts
@@ -1,19 +1,46 @@
 import type { Logger } from './logger'
 import { defaultLogger } from './logger'
 
+/** Processor that synchronously transforms a single chunk into an output value. */
 export type SyncProcessor<InputChunk, OutputChunk> = (chunk: InputChunk) => OutputChunk
+
+/**
+ * Processor that may return either a value (sync) or a Promise (async) for any
+ * given chunk. The executor detects which by duck-typing the return value.
+ */
 export type MixedProcessor<InputChunk, OutputChunk> = (
   chunk: InputChunk,
 ) => OutputChunk | Promise<OutputChunk>
+
+/**
+ * Pair of processors describing a sync-transform-then-async-flush pipeline.
+ *
+ * `syncTransform` runs on each input chunk; intermediates accumulate into a batch.
+ * `asyncPostProcess` receives the accumulated batch and may return any length of
+ * output array (so it can filter, expand, or pass through).
+ */
 export type TwoPhaseProcessor<InputChunk, IntermediateChunk, OutputChunk> = {
   syncTransform: (chunk: InputChunk) => IntermediateChunk
   asyncPostProcess: (intermediates: IntermediateChunk[]) => Promise<OutputChunk[]>
 }
 
+/** Options shared across all chunked executors. */
 export type ExecutionOptions = {
+  /** Identifier surfaced in warning messages so you can attribute slowness to a call site. */
   id: string
+  /**
+   * Upper bound (in milliseconds) on a single synchronous burst before the executor
+   * yields to the event loop via `setImmediate`. Set to `0` to yield after every
+   * chunk. Defaults to `15`.
+   */
   executeSynchronouslyThresholdInMsecs?: number
+  /**
+   * When a synchronous burst exceeds this threshold (in milliseconds), the executor
+   * emits one warning per burst describing the slowdown. Set to `0` to disable.
+   * Defaults to `30`.
+   */
   warningThresholdInMsecs?: number
+  /** Logger to receive warnings. Defaults to `defaultLogger` (which calls `console.warn`). */
   logger?: Logger
 }
 
@@ -23,93 +50,109 @@ export const defaultExecutionOptions = {
   logger: defaultLogger,
 } as const
 
-// Schedule new chunk after previous one is completed or process immediately if execution threshold not yet exceeded
-export function executeSyncChunksSequentially<InputChunk, OutputChunk>(
+type ResolvedOptions = ExecutionOptions & {
+  logger: Logger
+  executeSynchronouslyThresholdInMsecs: number
+}
+
+function resolveOptions(options: ExecutionOptions): ResolvedOptions {
+  return { ...defaultExecutionOptions, ...options }
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+/**
+ * Emits at most one warning per burst when `timeTaken` exceeds the warning threshold.
+ * Returns `true` once a warning has been emitted in the current burst so the caller
+ * can suppress duplicates until the next yield resets the latch.
+ */
+function maybeWarn(
+  options: ResolvedOptions,
+  alreadyWarned: boolean,
+  timeTaken: number,
+  chunkTimeTaken: number,
+  chunksProcessed: number,
+  chunk: unknown,
+): boolean {
+  if (alreadyWarned) return true
+  if (!options.warningThresholdInMsecs) return false
+  if (timeTaken < options.warningThresholdInMsecs) return false
+  const length = Array.isArray(chunk) || typeof chunk === 'string' ? chunk.length : 1
+  options.logger.warn(
+    `Execution "${options.id}" has exceeded the threshold, took ${timeTaken} msecs for a single iteration. ${chunksProcessed} chunks were processed. Last chunk took ${chunkTimeTaken} msecs for ${length} elements.`,
+  )
+  return true
+}
+
+/**
+ * Executes chunks through a synchronous processor, yielding to the event loop via
+ * `setImmediate` whenever a burst of work exceeds `executeSynchronouslyThresholdInMsecs`.
+ *
+ * Use this for CPU-bound transforms (parsing, validation, stemming) that would
+ * otherwise block the event loop for tens or hundreds of milliseconds. Results
+ * are returned in input order.
+ */
+export async function executeSyncChunksSequentially<InputChunk, OutputChunk>(
   inputChunks: readonly InputChunk[],
   processor: SyncProcessor<InputChunk, OutputChunk>,
   options: ExecutionOptions,
 ): Promise<OutputChunk[]> {
-  return new Promise((resolve, reject) => {
-    if (inputChunks.length === 0) {
-      return resolve([])
-    }
+  if (inputChunks.length === 0) {
+    return []
+  }
 
-    const results: OutputChunk[] = []
-    setImmediate(() =>
-      processIteration(
-        0,
-        inputChunks,
-        processor,
-        {
-          ...defaultExecutionOptions,
-          ...options,
-        },
-        results,
-        resolve,
-        reject,
-      ),
-    )
-  })
-}
+  const resolved = resolveOptions(options)
+  const results: OutputChunk[] = []
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This is intentional
-function processIteration<InputChunk, OutputChunk>(
-  _index: number,
-  inputs: readonly InputChunk[],
-  processor: SyncProcessor<InputChunk, OutputChunk>,
-  options: ExecutionOptions & {
-    logger: Logger
-    executeSynchronouslyThresholdInMsecs: number
-  },
-  results: OutputChunk[],
-  resolve: (output: OutputChunk[]) => void,
-  reject: (err: unknown) => void,
-) {
+  // Initial yield so callers see consistent async behavior regardless of input size
+  await yieldToEventLoop()
+
   let timeTaken = 0
   let chunksProcessed = 0
-  let stopProcessing = false
-  let index = _index
+  let warned = false
 
-  try {
-    while (!stopProcessing) {
-      const chunk = inputs[index]
-      const chunkStartTime = Date.now()
-      const chunkResult = processor(chunk)
-      const chunkTimeTaken = Date.now() - chunkStartTime
+  for (let index = 0; index < inputChunks.length; index++) {
+    const chunk = inputChunks[index]
+    const chunkStartTime = Date.now()
+    const chunkResult = processor(chunk)
+    const chunkTimeTaken = Date.now() - chunkStartTime
 
-      results.push(chunkResult)
-      timeTaken += chunkTimeTaken
-      chunksProcessed++
+    results.push(chunkResult)
+    timeTaken += chunkTimeTaken
+    chunksProcessed++
 
-      if (options.warningThresholdInMsecs) {
-        if (timeTaken >= options.warningThresholdInMsecs) {
-          const length = Array.isArray(chunk) || typeof chunk === 'string' ? chunk.length : 1
-          options.logger.warn(
-            `Execution "${options.id}" has exceeded the threshold, took ${timeTaken} msecs for a single iteration. ${chunksProcessed} chunks were processed. Last chunk took ${chunkTimeTaken} msecs for ${length} elements.`,
-          )
-        }
-      }
-      if (results.length !== inputs.length) {
-        // we haven't exceeded our threshold for deferred execution, let's continue
-        if (timeTaken < options.executeSynchronouslyThresholdInMsecs) {
-          index++
-        } else {
-          setImmediate(() =>
-            processIteration(index + 1, inputs, processor, options, results, resolve, reject),
-          )
-          stopProcessing = true
-        }
-      } else {
-        resolve(results)
-        stopProcessing = true
-      }
+    warned = maybeWarn(resolved, warned, timeTaken, chunkTimeTaken, chunksProcessed, chunk)
+
+    if (
+      index < inputChunks.length - 1 &&
+      timeTaken >= resolved.executeSynchronouslyThresholdInMsecs
+    ) {
+      await yieldToEventLoop()
+      timeTaken = 0
+      chunksProcessed = 0
+      warned = false
     }
-  } catch (err) {
-    reject(err)
   }
+
+  return results
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This is intentional
+/**
+ * Executes chunks through a processor that may return either a value or a Promise.
+ * When the processor returns a Promise, awaiting it naturally yields the event loop
+ * and resets the executor's burst counters. When it returns a value, the same
+ * threshold-based yielding as {@link executeSyncChunksSequentially} applies.
+ *
+ * **Important:** the async path must perform real async work (I/O, `setTimeout`,
+ * `setImmediate`) that actually yields the event loop. `await Promise.resolve(x)`
+ * resolves as a microtask on the current tick and does not yield — this executor
+ * resets its counter assuming the await yielded, but no yielding actually occurs.
+ * If your processor always returns synchronously-resolved promises (e.g. a cache
+ * that wraps results in `Promise.resolve()`), use {@link executeSyncChunksSequentially}
+ * and unwrap the cache synchronously instead.
+ */
 export async function executeMixedChunksSequentially<InputChunk, OutputChunk>(
   inputChunks: readonly InputChunk[],
   processor: MixedProcessor<InputChunk, OutputChunk>,
@@ -119,14 +162,14 @@ export async function executeMixedChunksSequentially<InputChunk, OutputChunk>(
     return []
   }
 
-  const resolvedOptions = { ...defaultExecutionOptions, ...options }
+  const resolved = resolveOptions(options)
   const results: OutputChunk[] = []
 
-  // Initial yield to match existing behavior
-  await new Promise<void>((resolve) => setImmediate(resolve))
+  await yieldToEventLoop()
 
   let timeTaken = 0
   let chunksProcessed = 0
+  let warned = false
 
   for (let index = 0; index < inputChunks.length; index++) {
     const chunk = inputChunks[index]
@@ -134,64 +177,57 @@ export async function executeMixedChunksSequentially<InputChunk, OutputChunk>(
     const rawResult = processor(chunk)
 
     // Duck-type thenable check (handles cross-realm promises and custom thenables)
-    if (
+    const isThenable =
       rawResult !== null &&
       rawResult !== undefined &&
       typeof (rawResult as Promise<OutputChunk>).then === 'function'
-    ) {
-      // Async path: await the promise, then reset counters since event loop was yielded
-      const chunkResult = await (rawResult as Promise<OutputChunk>)
-      const chunkTimeTaken = Date.now() - chunkStartTime
 
-      results.push(chunkResult)
-      timeTaken += chunkTimeTaken
-      chunksProcessed++
+    const chunkResult: OutputChunk = isThenable
+      ? await (rawResult as Promise<OutputChunk>)
+      : (rawResult as OutputChunk)
+    const chunkTimeTaken = Date.now() - chunkStartTime
 
-      if (resolvedOptions.warningThresholdInMsecs) {
-        if (timeTaken >= resolvedOptions.warningThresholdInMsecs) {
-          const length = Array.isArray(chunk) || typeof chunk === 'string' ? chunk.length : 1
-          resolvedOptions.logger.warn(
-            `Execution "${resolvedOptions.id}" has exceeded the threshold, took ${timeTaken} msecs for a single iteration. ${chunksProcessed} chunks were processed. Last chunk took ${chunkTimeTaken} msecs for ${length} elements.`,
-          )
-        }
-      }
+    results.push(chunkResult)
+    timeTaken += chunkTimeTaken
+    chunksProcessed++
 
+    warned = maybeWarn(resolved, warned, timeTaken, chunkTimeTaken, chunksProcessed, chunk)
+
+    if (isThenable) {
       // The await already yielded the event loop, reset counters
       timeTaken = 0
       chunksProcessed = 0
-    } else {
-      // Sync path: identical to executeSyncChunksSequentially behavior
-      const chunkResult = rawResult as OutputChunk
-      const chunkTimeTaken = Date.now() - chunkStartTime
-
-      results.push(chunkResult)
-      timeTaken += chunkTimeTaken
-      chunksProcessed++
-
-      if (resolvedOptions.warningThresholdInMsecs) {
-        if (timeTaken >= resolvedOptions.warningThresholdInMsecs) {
-          const length = Array.isArray(chunk) || typeof chunk === 'string' ? chunk.length : 1
-          resolvedOptions.logger.warn(
-            `Execution "${resolvedOptions.id}" has exceeded the threshold, took ${timeTaken} msecs for a single iteration. ${chunksProcessed} chunks were processed. Last chunk took ${chunkTimeTaken} msecs for ${length} elements.`,
-          )
-        }
-      }
-
-      // Yield to event loop when sync threshold exceeded (and more chunks remain)
-      if (
-        index < inputChunks.length - 1 &&
-        timeTaken >= resolvedOptions.executeSynchronouslyThresholdInMsecs
-      ) {
-        await new Promise<void>((resolve) => setImmediate(resolve))
-        timeTaken = 0
-        chunksProcessed = 0
-      }
+      warned = false
+    } else if (
+      index < inputChunks.length - 1 &&
+      timeTaken >= resolved.executeSynchronouslyThresholdInMsecs
+    ) {
+      await yieldToEventLoop()
+      timeTaken = 0
+      chunksProcessed = 0
+      warned = false
     }
   }
 
   return results
 }
 
+/**
+ * Executes chunks in two explicit phases: a synchronous transform that accumulates
+ * intermediates into a batch, followed by an async post-processing step (e.g. a bulk
+ * database insert). Sync transforms run back-to-back until
+ * `executeSynchronouslyThresholdInMsecs` is exceeded or the last chunk is reached,
+ * then the accumulated batch is flushed to `asyncPostProcess`. The async phase
+ * naturally yields the event loop and resets the burst counters.
+ *
+ * Setting `executeSynchronouslyThresholdInMsecs: 0` flushes after every sync transform
+ * — useful when downstream ordering or backpressure dictates one-at-a-time processing.
+ * Output order is preserved across batches (each `asyncPostProcess` call is awaited
+ * before the next sync transform begins).
+ *
+ * `asyncPostProcess` may return an array of any length, allowing filtering or
+ * expansion during post-processing.
+ */
 export async function executeTwoPhaseChunksSequentially<InputChunk, IntermediateChunk, OutputChunk>(
   inputChunks: readonly InputChunk[],
   processor: TwoPhaseProcessor<InputChunk, IntermediateChunk, OutputChunk>,
@@ -201,20 +237,18 @@ export async function executeTwoPhaseChunksSequentially<InputChunk, Intermediate
     return []
   }
 
-  const resolvedOptions = { ...defaultExecutionOptions, ...options }
+  const resolved = resolveOptions(options)
   const results: OutputChunk[] = []
 
-  // Initial yield to match existing behavior
-  await new Promise<void>((resolve) => setImmediate(resolve))
+  await yieldToEventLoop()
 
   let timeTaken = 0
   let chunksProcessed = 0
+  let warned = false
   let pendingIntermediates: IntermediateChunk[] = []
 
   for (let index = 0; index < inputChunks.length; index++) {
     const chunk = inputChunks[index]
-
-    // Phase 1: Synchronous transform — accumulate intermediates
     const chunkStartTime = Date.now()
     const intermediate = processor.syncTransform(chunk)
     const chunkTimeTaken = Date.now() - chunkStartTime
@@ -223,25 +257,28 @@ export async function executeTwoPhaseChunksSequentially<InputChunk, Intermediate
     timeTaken += chunkTimeTaken
     chunksProcessed++
 
-    if (resolvedOptions.warningThresholdInMsecs) {
-      if (timeTaken >= resolvedOptions.warningThresholdInMsecs) {
-        const length = Array.isArray(chunk) || typeof chunk === 'string' ? chunk.length : 1
-        resolvedOptions.logger.warn(
-          `Execution "${resolvedOptions.id}" has exceeded the threshold, took ${timeTaken} msecs for a single iteration. ${chunksProcessed} chunks were processed. Last chunk took ${chunkTimeTaken} msecs for ${length} elements.`,
-        )
-      }
-    }
+    warned = maybeWarn(resolved, warned, timeTaken, chunkTimeTaken, chunksProcessed, chunk)
 
-    // Flush when sync threshold is exceeded or on the last chunk
     const isLastChunk = index === inputChunks.length - 1
-    if (isLastChunk || timeTaken >= resolvedOptions.executeSynchronouslyThresholdInMsecs) {
-      // Phase 2: Async post-processing of accumulated batch (yields to event loop naturally)
+    if (isLastChunk || timeTaken >= resolved.executeSynchronouslyThresholdInMsecs) {
       const batchResults = await processor.asyncPostProcess(pendingIntermediates)
-      results.push(...batchResults)
+      // Append via indexed push instead of `results.push(...batchResults)`:
+      // spread would exceed V8's argument-count limit (~65535) for large async
+      // batches (RangeError), which the headline use case (bulk DB returning
+      // rows) can hit. Indexed push is safe at any size and keeps the result
+      // array PACKED — preallocation via `results.length = ...` would force a
+      // HOLEY transition that costs more in downstream iteration than it saves
+      // here. The ~1.3x overhead vs spread is negligible next to the I/O cost
+      // of `asyncPostProcess` itself.
+      const batchLen = batchResults.length
+      for (let i = 0; i < batchLen; i++) {
+        results.push(batchResults[i])
+      }
 
       pendingIntermediates = []
       timeTaken = 0
       chunksProcessed = 0
+      warned = false
     }
   }
 

--- a/src/butterSpread.ts
+++ b/src/butterSpread.ts
@@ -56,7 +56,11 @@ type ResolvedOptions = ExecutionOptions & {
 }
 
 function resolveOptions(options: ExecutionOptions): ResolvedOptions {
-  return { ...defaultExecutionOptions, ...options }
+  return {
+    ...defaultExecutionOptions,
+    ...options,
+    logger: options.logger ?? defaultExecutionOptions.logger,
+  }
 }
 
 function yieldToEventLoop(): Promise<void> {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,8 +7,27 @@ export type LogFn = {
   (msg: string, ...args: any[]): void
 }
 
+/**
+ * Minimal logger interface used for emitting threshold-exceeded warnings.
+ * The shape is intentionally pino-compatible so common structured loggers can be
+ * passed in directly.
+ */
 export type Logger = {
   warn: LogFn
 }
 
-export const defaultLogger: Logger = console
+/**
+ * Default logger used by the executors when no `logger` option is passed. Backed by
+ * `console.warn` — only the `warn` method is exposed (the rest of `console` is not
+ * part of the surface area).
+ *
+ * The wrapper resolves `console.warn` at call time so test spies on `console.warn`
+ * (and any later console replacement) are picked up.
+ */
+export const defaultLogger: Logger = {
+  // biome-ignore lint/suspicious/noExplicitAny: matches the LogFn overloaded signature
+  warn: ((...args: any[]) => {
+    // biome-ignore lint/suspicious/noExplicitAny: pass-through to console.warn
+    ;(console.warn as (...a: any[]) => void)(...args)
+  }) as LogFn,
+}

--- a/src/streamUtils.ts
+++ b/src/streamUtils.ts
@@ -1,5 +1,15 @@
 import type { Writable } from 'node:stream'
 
+/**
+ * Accumulates items from any `Iterable` or `AsyncIterable` (including Node.js readable
+ * streams) into fixed-size batches. The final batch may be smaller than `batchSize`.
+ *
+ * Useful for composing stream consumption with chunked processing — feed each batch
+ * into {@link executeTwoPhaseChunksSequentially} or similar.
+ *
+ * @param source Any sync or async iterable.
+ * @param batchSize Maximum items per yielded batch (must be >= 1).
+ */
 export async function* batchFromStream<T>(
   source: Iterable<T> | AsyncIterable<T>,
   batchSize: number,
@@ -19,23 +29,34 @@ export async function* batchFromStream<T>(
   }
 }
 
+/**
+ * Writes `data` to a `Writable` stream while respecting backpressure. Resolves when
+ * the chunk has been accepted by the consumer (or after the next `drain` event when
+ * the internal buffer was full). Rejects if the stream errors, is destroyed, or
+ * closes before the write completes.
+ *
+ * Prefer `stream.pipeline()` when your data source can be expressed as a readable
+ * stream or async iterable — `drainAwareWrite` is for the case where you write
+ * imperatively in a loop and can't restructure as a pipeline.
+ */
 export function drainAwareWrite(stream: Writable, data: string | Buffer): Promise<void> {
   return new Promise((resolve, reject) => {
     let settled = false
+    // Initial value covers the rare case where the write callback fires synchronously
+    // during `stream.write(...)`, before the return value has been assigned. Reading
+    // an uninitialized `const` would throw a TDZ ReferenceError.
+    let canContinue = true
 
-    const cleanup = () => {
+    const settle = (err?: Error | null) => {
+      if (settled) return
+      settled = true
       // Defer listener removal to allow Node.js to emit the 'error' event
       // that follows a failed write callback on the next tick
       setImmediate(() => {
         stream.removeListener('error', onError)
         stream.removeListener('drain', onDrain)
+        stream.removeListener('close', onClose)
       })
-    }
-
-    const settle = (err?: Error | null) => {
-      if (settled) return
-      settled = true
-      cleanup()
       if (err) {
         reject(err)
       } else {
@@ -45,10 +66,12 @@ export function drainAwareWrite(stream: Writable, data: string | Buffer): Promis
 
     const onError = (err: Error) => settle(err)
     const onDrain = () => settle()
+    const onClose = () => settle(new Error('Stream closed before drainAwareWrite completed'))
 
-    stream.on('error', onError)
+    stream.once('error', onError)
+    stream.once('close', onClose)
 
-    const canContinue = stream.write(data, (err) => {
+    canContinue = stream.write(data, (err) => {
       if (err) {
         settle(err)
       } else if (canContinue) {

--- a/src/stringUtils.ts
+++ b/src/stringUtils.ts
@@ -1,21 +1,49 @@
+/**
+ * Finds the position to cut a segment of `fullText` that starts at `startPos` and
+ * is at most `maxLength` characters long, preferring whitespace boundaries. Walks
+ * back over consecutive trailing spaces so the resulting substring never ends with
+ * whitespace.
+ */
+function findSegmentEnd(fullText: string, startPos: number, maxLength: number): number {
+  const endPos = Math.min(startPos + maxLength, fullText.length)
+  if (endPos >= fullText.length) {
+    return endPos
+  }
+
+  let spacePos = fullText.lastIndexOf(' ', endPos)
+  if (spacePos === -1 || spacePos <= startPos) {
+    // No space within the window — extend to the next space (or to end)
+    spacePos = fullText.indexOf(' ', endPos)
+    return spacePos === -1 ? fullText.length : spacePos
+  }
+
+  // Walk back over consecutive spaces so the segment doesn't end with whitespace
+  while (spacePos > startPos && fullText[spacePos - 1] === ' ') {
+    spacePos--
+  }
+  return spacePos
+}
+
+/**
+ * Splits `fullText` into segments no longer than `maxLength` characters, trying to
+ * split at whitespace so words are preserved across segments. Words longer than
+ * `maxLength` are emitted on their own (the function never breaks a word in half).
+ *
+ * Consecutive whitespace at split points is collapsed: emitted segments are
+ * trimmed of leading and trailing spaces.
+ */
 export function splitTextPreserveWords(fullText: string, maxLength: number): string[] {
-  const result = []
+  const result: string[] = []
   let startPos = 0
 
   while (startPos < fullText.length) {
-    let endPos = Math.min(startPos + maxLength, fullText.length)
-    if (endPos < fullText.length) {
-      let spacePos = fullText.lastIndexOf(' ', endPos)
-      if (spacePos === -1 || spacePos <= startPos) {
-        // No spaces found, find the next space after the maxLength
-        spacePos = fullText.indexOf(' ', endPos)
-        endPos = spacePos === -1 ? fullText.length : spacePos
-      } else {
-        // Space found before maxLength, split at the space
-        endPos = spacePos
-      }
+    // Skip leading whitespace so segments never start with a space
+    while (startPos < fullText.length && fullText[startPos] === ' ') {
+      startPos++
     }
+    if (startPos >= fullText.length) break
 
+    const endPos = findSegmentEnd(fullText, startPos, maxLength)
     result.push(fullText.substring(startPos, endPos))
     startPos = endPos + (fullText[endPos] === ' ' ? 1 : 0)
   }
@@ -23,25 +51,21 @@ export function splitTextPreserveWords(fullText: string, maxLength: number): str
   return result
 }
 
+/**
+ * Returns a single slice of `fullText` starting at `startPos` (default 0), at most
+ * `sliceSize` characters long, ending at a whitespace boundary when possible. Words
+ * longer than `sliceSize` are returned on their own.
+ *
+ * `startPos` is expected to coincide with a word boundary (for example, the index
+ * returned as the end of a previous slice). If it lands mid-word, the returned
+ * slice will start mid-word too.
+ */
 export function getSlicePreserveWords(
   fullText: string,
   sliceSize: number,
   _startPos?: number,
 ): string {
   const startPos = _startPos ?? 0
-
-  let endPos = Math.min(startPos + sliceSize, fullText.length)
-  if (endPos < fullText.length) {
-    let spacePos = fullText.lastIndexOf(' ', endPos)
-    if (spacePos === -1 || spacePos <= startPos) {
-      // No spaces found, find the next space after the maxLength
-      spacePos = fullText.indexOf(' ', endPos)
-      endPos = spacePos === -1 ? fullText.length : spacePos
-    } else {
-      // Space found before maxLength, split at the space
-      endPos = spacePos
-    }
-  }
-
+  const endPos = findSegmentEnd(fullText, startPos, sliceSize)
   return fullText.substring(startPos, endPos)
 }

--- a/test/butterSpread.twoPhase.spec.ts
+++ b/test/butterSpread.twoPhase.spec.ts
@@ -224,6 +224,24 @@ describe('executeTwoPhaseChunksSequentially', () => {
     ).rejects.toThrow(/Sync broke/)
   })
 
+  it('handles asyncPostProcess returning a batch larger than V8 spread limit', async () => {
+    // V8's argument-count limit (~65535) would cause `results.push(...batchResults)`
+    // to throw RangeError. Regression test for the indexed-push fix.
+    const LARGE_SIZE = 70_000
+    const results = await executeTwoPhaseChunksSequentially(
+      [1],
+      {
+        syncTransform: (n: number) => n,
+        asyncPostProcess: async () => Array.from({ length: LARGE_SIZE }, (_, i) => i),
+      },
+      { id: 'large-batch' },
+    )
+
+    expect(results.length).toBe(LARGE_SIZE)
+    expect(results[0]).toBe(0)
+    expect(results[LARGE_SIZE - 1]).toBe(LARGE_SIZE - 1)
+  })
+
   it('throws an error if async post-process rejects', async () => {
     await expect(
       executeTwoPhaseChunksSequentially(

--- a/test/streamUtils.spec.ts
+++ b/test/streamUtils.spec.ts
@@ -156,4 +156,22 @@ describe('drainAwareWrite', () => {
 
     await expect(drainAwareWrite(writable, 'data')).rejects.toThrow(/Write failed/)
   })
+
+  it('rejects when stream closes mid-write without emitting error', async () => {
+    // Hold the write callback so the write stays "in flight", then emit 'close'
+    // directly. The cb-error path and the 'error' listener are both bypassed —
+    // only the 'close' safety net should settle the promise.
+    const writable = new Writable({
+      write(_chunk, _encoding, _callback) {
+        // intentionally never invoke callback
+      },
+    })
+
+    const writePromise = drainAwareWrite(writable, 'data')
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    writable.emit('close')
+
+    await expect(writePromise).rejects.toThrow(/Stream closed/)
+  })
 })

--- a/test/stringUtils.spec.ts
+++ b/test/stringUtils.spec.ts
@@ -44,6 +44,19 @@ describe('stringUtils', () => {
 
       expect(result).toEqual(['Mytextisthis.jpg'])
     })
+
+    it('collapses consecutive whitespace at split points', () => {
+      // Old behavior would emit 'foo ' (trailing space) for the first segment
+      const result = splitTextPreserveWords('foo  bar', 5)
+
+      expect(result).toEqual(['foo', 'bar'])
+    })
+
+    it('handles multiple consecutive spaces between words', () => {
+      const result = splitTextPreserveWords('foo   bar baz', 5)
+
+      expect(result).toEqual(['foo', 'bar', 'baz'])
+    })
   })
 
   describe('getSlicePreserveWords', () => {
@@ -117,6 +130,14 @@ describe('stringUtils', () => {
       const result = getSlicePreserveWords('Mytextisthis.jpg', 1)
 
       expect(result).toBe('Mytextisthis.jpg')
+    })
+
+    it('returns mid-word slice when startPos lands inside a word', () => {
+      // Documented precondition: startPos should coincide with a word boundary.
+      // When it doesn't, the slice starts mid-word (no attempt to snap forward).
+      const result = getSlicePreserveWords('hello world', 5, 3)
+
+      expect(result).toBe('lo')
     })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "dist",
     "module": "CommonJS",
     "target": "ES2022",
-    "lib": ["ES2022", "dom"],
+    "lib": ["ES2022"],
     "sourceMap": false,
     "declaration": true,
     "declarationMap": false,


### PR DESCRIPTION
## Summary

Addresses the prioritized review items: two real bugs, one ergonomic crash risk, several smaller bugs, and a documentation pass adding TSDoc to every export. Snapshots are untouched; all 77 tests pass with 100% statement/line/function coverage.

### Bugs fixed
- **`drainAwareWrite` TDZ**: `canContinue` was a `const` whose initializer (`stream.write(...)`) could synchronously fire the write callback that reads `canContinue` — throwing `ReferenceError`. Declared as `let` with a safe default.
- **`drainAwareWrite` hang on `'close'` without `'error'`**: added a `'close'` listener that rejects with a descriptive error so the promise can't dangle forever.
- **`executeTwoPhaseChunksSequentially` RangeError on large batches**: `results.push(...batchResults)` blows up at V8's ~65 535 argument limit — exactly the case the headline use case (bulk DB returning rows) hits. Replaced with an indexed-push loop. Comment explains why this beats both spread and preallocation.

### Perf / structure
- All three executors are now async/await + for-loop. Drops the recursive `setImmediate` model and its cognitive-complexity waiver.
- Extracted `maybeWarn` helper with per-burst latch — no more duplicate warnings within one sync burst.
- `tsconfig.json` no longer pulls in DOM types (server-only lib).
- `@types/node` bumped to `^22` to match `engines.node >= 22.13`.

### Smaller bugs
- `splitTextPreserveWords` no longer emits leading/trailing whitespace when the input contains consecutive spaces.
- `defaultLogger` exposes only `warn` (was structurally the entire `console`), with a lazy wrapper so `vitest.spyOn(console, 'warn')` still intercepts.
- `chunk` rejects `NaN`/`Infinity` chunk sizes alongside the existing `< 1` guard.

### Docs
- TSDoc on every exported function and type, including a warning on `MixedProcessor` that `Promise.resolve(x)` resolves as a microtask and does not yield the event loop.
- README: Node 22.13 requirement, `setImmediate` as the yield primitive, `executeSynchronouslyThresholdInMsecs: 0` behavior, `getSlicePreserveWords` `startPos` precondition, and the Logger interface.

### Tests
- Two-phase: regression test for `asyncPostProcess` returning >65 535 items.
- `drainAwareWrite`: rejection when the stream emits `'close'` without `'error'`.
- stringUtils: consecutive-whitespace and mid-word `startPos` coverage.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run test:ci` (77/77 tests pass, 100% statements/lines/functions, 96.73% branches)
- [ ] Sanity-check on a downstream consumer that uses `executeTwoPhaseChunksSequentially` with a large `asyncPostProcess` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Logger interface definition with `warn` method support.

* **Bug Fixes**
  * Improved stream handling for close events during pending writes.
  * Enhanced text segmentation to correctly handle consecutive whitespace.

* **Documentation**
  * Updated Node.js engine requirement to `>= 22.13`.
  * Documented async yielding behavior and executor thresholds.

* **Chores**
  * Updated Node type definitions to align with Node.js 22 requirement.
  * Updated TypeScript configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kibertoad/butter-spread/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->